### PR TITLE
Fix backend deployment by modifying sys.path

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+# Add the project root to the Python path
+root_dir = Path(__file__).resolve().parent.parent
+sys.path.append(str(root_dir))
+
 from fastapi import FastAPI, APIRouter, WebSocket, WebSocketDisconnect, HTTPException, UploadFile, File, Form, Depends
 from fastapi.responses import StreamingResponse
 from dotenv import load_dotenv
@@ -5,7 +11,6 @@ from starlette.middleware.cors import CORSMiddleware
 from motor.motor_asyncio import AsyncIOMotorClient
 import os
 import logging
-from pathlib import Path
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional
 import uuid


### PR DESCRIPTION
This commit fixes the `ModuleNotFoundError` during backend deployment by programmatically adding the project's root directory to the Python path at runtime.

Previous attempts to fix this by using relative imports or turning the `backend` directory into a package were unsuccessful on the Render deployment platform. This `sys.path` modification is a more direct approach to ensure that the `backend` module is discoverable by the Python interpreter, regardless of the working directory from which the `uvicorn` command is executed.

This should resolve the persistent import errors and allow the backend to deploy successfully.