### PR TITLE
fix: Add bcrypt dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ pydantic>=2.6.4
 email-validator>=2.2.0
 pyjwt>=2.10.1
 passlib>=1.7.4
+bcrypt>=4.0.1
 tzdata>=2024.2
 motor==3.3.1
 pytest>=8.0.0


### PR DESCRIPTION
This commit adds the `bcrypt` library to the backend dependencies. This is required by the `passlib` library for password hashing and resolves the `MissingBackendError` that was preventing you from creating an account and logging in.