### PR TITLE
fix: Resolve library incompatibility causing login failure

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,8 +8,7 @@ pymongo==4.5.0
 pydantic>=2.6.4
 email-validator>=2.2.0
 pyjwt>=2.10.1
-passlib>=1.7.4
-bcrypt>=4.0.1
+passlib[bcrypt]>=1.7.4
 tzdata>=2024.2
 motor==3.3.1
 pytest>=8.0.0


### PR DESCRIPTION
This commit addresses a login failure caused by a version incompatibility between the `passlib` and `bcrypt` libraries.

The error `AttributeError: module 'bcrypt' has no attribute '__about__'` was being thrown because the version of `bcrypt` installed was not compatible with the `passlib` version.

The fix is to specify `passlib[bcrypt]` in `requirements.txt`. This ensures that `pip` installs a version of `bcrypt` that is known to be compatible with `passlib`, resolving the internal error during password verification. The explicit `bcrypt` dependency has been removed to avoid conflicts.