### PR TITLE
fix: Resolve CORS issue by removing conflicting middleware

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -704,21 +704,9 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
 app.include_router(api_router)
 app.include_router(auth_router)
 
-from starlette.requests import Request
-from starlette.responses import Response
-
-@app.middleware("http")
-async def add_cors_header(request: Request, call_next):
-    response = await call_next(request)
-    response.headers['Access-Control-Allow-Origin'] = 'https://stc-hub-vcq4.vercel.app'
-    response.headers['Access-Control-Allow-Credentials'] = 'true'
-    response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
-    response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
-    return response
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://stc-hub-vcq4.vercel.app", "http://localhost:3000"],
+    allow_origins=["https://stc-hub-vcq4.vercel.app", "http://localhost:3000", "https://stc-hub.onrender.com"],
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=True,


### PR DESCRIPTION
This commit fixes the CORS (Cross-Origin Resource Sharing) error that was preventing the frontend from communicating with the backend.

The root cause was a redundant, custom CORS middleware that was conflicting with the standard FastAPI `CORSMiddleware`. This conflict resulted in the necessary `Access-Control-Allow-Origin` header not being sent in some cases.

The fix involves:
- Removing the custom `@app.middleware("http")` function `add_cors_header`.
- Relying solely on the standard `CORSMiddleware`.
- Adding the backend's own domain to the `allow_origins` list to be safe.

This change ensures that CORS headers are handled correctly and consistently, allowing the frontend to make requests to the backend without being blocked by browser security policies.