### PR TITLE
fix: Resolve login failure by handling MongoDB ObjectId

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -576,6 +576,9 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends()):
         data={"sub": user["email"], "id": user["id"]}, expires_delta=access_token_expires
     )
 
+    # Remove the non-serializable ObjectId before returning the user object
+    user.pop("_id", None)
+
     return {"access_token": access_token, "token_type": "bearer", "user": user}
 
 


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error that occurred during login. The error was caused by a `TypeError` when FastAPI's `jsonable_encoder` tried to serialize the `ObjectId` type from a MongoDB document.

The fix involves removing the non-serializable `_id` field from the user dictionary before it is returned by the login API endpoint. The application uses a separate, string-based `id` field for identifying users, so the `_id` field is not needed in the response.